### PR TITLE
Add test for reader, correct references and their allocation and cleanup

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -68,10 +68,12 @@ pub fn build(b: *std.Build) void {
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
+    const test_filters = b.option([]const []const u8, "test-filter", "Skip tests that do not match any filter") orelse &[0][]const u8{};
     const sdk_unit_tests = b.addTest(.{
         .root_source_file = b.path("src/sdk.zig"),
         .target = target,
         .optimize = optimize,
+        .filters = test_filters,
     });
     sdk_unit_tests.root_module.addImport("protobuf", protobuf_dep.module("protobuf"));
 

--- a/src/metrics/reader.zig
+++ b/src/metrics/reader.zig
@@ -111,6 +111,7 @@ test "metric reader collects data from meter provider" {
     try mp.addReader(&reader);
 
     const m = try mp.getMeter(.{ .name = "my-meter" });
+
     var counter = try m.createCounter(u32, .{ .name = "my-counter" });
     try counter.add(1, null);
 

--- a/src/metrics/reader.zig
+++ b/src/metrics/reader.zig
@@ -63,13 +63,12 @@ pub const MetricReader = struct {
             .name = ManagedString.managed(i.opts.name),
             .description = if (i.opts.description) |d| ManagedString.managed(d) else .Empty,
             .unit = if (i.opts.unit) |u| ManagedString.managed(u) else .Empty,
-            .data = null,
-            // .data = switch (i.data) {
-            //     .Counter_u32 => pbmetrics.Metric.data_union{ .sum = pbmetrics.Sum{
-            //         .data_points = try sumDataPoints(allocator, u32, i.data.Counter_u32),
-            //     } },
-            //     else => unreachable,
-            // },
+            .data = switch (i.data) {
+                .Counter_u32 => pbmetrics.Metric.data_union{ .sum = pbmetrics.Sum{
+                    .data_points = try sumDataPoints(allocator, u32, i.data.Counter_u32),
+                } },
+                else => unreachable,
+            },
             // Metadata used for internal translations and we can discard for now.
             // Consumers of SDK should not rely on this field.
             .metadata = std.ArrayList(pbcommon.KeyValue).init(allocator),

--- a/src/metrics/reader.zig
+++ b/src/metrics/reader.zig
@@ -103,6 +103,21 @@ test "metric reader shutdown prevents collect() to execute" {
     try reader.collect();
 }
 
+test "metric reader collects data from meter provider" {
+    var mp = try MeterProvider.init(std.testing.allocator);
+    defer mp.shutdown();
+    var reader = MetricReader{ .allocator = std.testing.allocator };
+    defer reader.shutdown();
+
+    try mp.addReader(&reader);
+
+    const m = try mp.getMeter(.{ .name = "my-meter" });
+    var counter = try m.createCounter(u32, .{ .name = "my-counter" });
+    try counter.add(1, null);
+
+    try reader.collect();
+}
+
 pub const MetricExporter = struct {
     exporter: *const fn (pbmetrics.ExportMetricsServiceRequest) MetricReadError!void,
 };

--- a/src/metrics/spec.zig
+++ b/src/metrics/spec.zig
@@ -183,14 +183,14 @@ test "meter identifier changes with different schema url" {
 /// Identify an instrument in a meter by its name, kind, unit and description.
 /// Used to recognize duplicate instrument registration as defined in
 /// https://opentelemetry.io/docs/specs/otel/metrics/sdk/#duplicate-instrument-registration.
-/// Returned identifier must be freed by the caller using the allocator.
 pub fn instrumentIdentifier(allocator: std.mem.Allocator, name: []const u8, kind: []const u8, unit: []const u8, description: []const u8) ![]u8 {
     var h = std.hash.Wyhash.init(42);
     h.update(description);
     const id = h.final();
     const lowerName = try std.ascii.allocLowerString(allocator, name);
     defer allocator.free(lowerName);
-    return try std.fmt.allocPrint(allocator, "{s}-{s}-{s}-{x}", .{ lowerName, kind, unit, id });
+    var buf: [4096]u8 = [_]u8{0} ** 4096;
+    return std.fmt.bufPrintZ(&buf, "{s}-{s}-{s}-{x}", .{ lowerName, kind, unit, id });
 }
 
 test "identifying field for instrument remain equal upon similar name with mixed case" {
@@ -201,9 +201,7 @@ test "identifying field for instrument remain equal upon similar name with mixed
     const alloc = std.testing.allocator;
 
     const a = try instrumentIdentifier(alloc, name, kind, "", description);
-    defer alloc.free(a);
     const b = try instrumentIdentifier(alloc, equivalentName, kind, "", description);
-    defer alloc.free(b);
     std.debug.assert(std.mem.eql(u8, a, b));
 }
 
@@ -216,9 +214,7 @@ test "identifying fields for instruments change with unit" {
     const alloc = std.testing.allocator;
 
     const a = try instrumentIdentifier(alloc, name, kind, "", description);
-    defer alloc.free(a);
     const b = try instrumentIdentifier(alloc, name, kind, "bytes", description);
-    defer alloc.free(b);
     std.debug.assert(!std.mem.eql(u8, a, b));
 }
 

--- a/src/pbutils.zig
+++ b/src/pbutils.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const protobuf = @import("protobuf");
+const ManagedString = protobuf.ManagedString;
 const pbcommon = @import("opentelemetry/proto/common/v1.pb.zig");
 
 // Converts a key-value pair into a pbcommon.KeyValue.
@@ -12,10 +13,11 @@ fn keyValue(comptime T: type) type {
 
         fn resolve(self: keyValue(T)) pbcommon.KeyValue {
             return pbcommon.KeyValue{
-                .key = .{ .Const = self.key },
+                .key = ManagedString.managed(self.key),
                 .value = switch (@TypeOf(self.value)) {
                     bool => pbcommon.AnyValue{ .value = .{ .bool_value = self.value } },
-                    []const u8 => pbcommon.AnyValue{ .value = .{ .string_value = .{ .Const = self.value } } },
+                    []const u8 => pbcommon.AnyValue{ .value = .{ .string_value = ManagedString.managed(self.value) } },
+                    []u8 => pbcommon.AnyValue{ .value = .{ .string_value = ManagedString.managed(self.value) } },
                     i64 => pbcommon.AnyValue{ .value = .{ .int_value = self.value } },
                     f64 => pbcommon.AnyValue{ .value = .{ .double_value = self.value } },
                     else => @compileError("unsupported value type for attribute " ++ @typeName(@TypeOf(self.value))),


### PR DESCRIPTION
### Reason for this PR

Adding unit test to ensure `MetricReader.collect()` actually exports data.


### Details

The additional test `metric reader collects data from meter provider` is marked as leaking by the testing allocator.
Here's the output

```
☁  opentelemetry-zig [reader-test] zig build test              
test
└─ run test 33/33 passed, 1 leaked
error: 'metrics.reader.test.metric reader collects data from meter provider' leaked: Instrument with identifying name some-counter-Counter--72014e4eed7eeb7d already exists in meter my-meter
[gpa] (err): memory address 0x7f943f672040 leaked: 
/usr/local/zig-linux-x86_64-0.13.0/lib/std/fmt.zig:1802:36: 0x109f80e in allocPrint__anon_10778 (test)
    const buf = try allocator.alloc(u8, size);
                                   ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/spec.zig:193:34: 0x109bbee in instrumentIdentifier (test)
    return try std.fmt.allocPrint(allocator, "{s}-{s}-{s}-{x}", .{ lowerName, kind, unit, id });
                                 ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/meter.zig:160:49: 0x109fb73 in registerInstrument (test)
        const id = try spec.instrumentIdentifier(
                                                ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/meter.zig:120:36: 0x10a8363 in createCounter__anon_10931 (test)
        try self.registerInstrument(i);
                                   ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/reader.zig:114:38: 0x10dccc5 in test.metric reader collects data from meter provider (test)
    var counter = try m.createCounter(u32, .{ .name = "my-counter" });
                                     ^
/usr/local/zig-linux-x86_64-0.13.0/lib/compiler/test_runner.zig:95:29: 0x1062d23 in mainServer (test)
                test_fn.func() catch |err| switch (err) {
                            ^
/usr/local/zig-linux-x86_64-0.13.0/lib/compiler/test_runner.zig:35:26: 0x1059c1e in main (test)
        return mainServer() catch @panic("internal test runner failure");
                         ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/start.zig:514:22: 0x10592b9 in posixCallMainAndExit (test)
            root.main();
                     ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/start.zig:266:5: 0x1058e21 in _start (test)
    asm volatile (switch (native_arch) {
    ^

[gpa] (err): memory address 0x7f943f66a000 leaked: 
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1605:53: 0x1149468 in allocate (test)
            const slice = try allocator.alignedAlloc(u8, max_align, total_size);
                                                    ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1562:29: 0x1137bed in grow (test)
            try map.allocate(allocator, new_cap);
                            ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1512:30: 0x1123e77 in growIfNeeded (test)
                try self.grow(allocator, capacityForSize(self.load() + new_count), ctx);
                             ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1333:34: 0x1106359 in getOrPutContextAdapted__anon_13550 (test)
                self.growIfNeeded(allocator, 1, ctx) catch |err| {
                                 ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1318:56: 0x10e11de in getOrPutContext (test)
            const gop = try self.getOrPutContextAdapted(allocator, key, ctx, ctx);
                                                       ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1244:52: 0x10cb006 in putContext (test)
            const result = try self.getOrPutContext(allocator, key, ctx);
                                                   ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:552:45: 0x10a855d in put (test)
            return self.unmanaged.putContext(self.allocator, key, value, self.ctx);
                                            ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/instrument.zig:176:40: 0x10a846f in add (test)
                try self.cumulative.put(key, delta);
                                       ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/reader.zig:115:20: 0x10dcd3c in test.metric reader collects data from meter provider (test)
    try counter.add(1, null);
                   ^
/usr/local/zig-linux-x86_64-0.13.0/lib/compiler/test_runner.zig:95:29: 0x1062d23 in mainServer (test)
                test_fn.func() catch |err| switch (err) {
                            ^

[gpa] (err): memory address 0x7f943f66b000 leaked: 
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1605:53: 0x11475f8 in allocate (test)
            const slice = try allocator.alignedAlloc(u8, max_align, total_size);
                                                    ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1562:29: 0x1135ced in grow (test)
            try map.allocate(allocator, new_cap);
                            ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1512:30: 0x1120e07 in growIfNeeded (test)
                try self.grow(allocator, capacityForSize(self.load() + new_count), ctx);
                             ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1333:34: 0x1100a94 in getOrPutContextAdapted__anon_13486 (test)
                self.growIfNeeded(allocator, 1, ctx) catch |err| {
                                 ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1318:56: 0x10deead in getOrPutContext (test)
            const gop = try self.getOrPutContextAdapted(allocator, key, ctx, ctx);
                                                       ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:1244:52: 0x10c3a7b in putContext (test)
            const result = try self.getOrPutContext(allocator, key, ctx);
                                                   ^
/usr/local/zig-linux-x86_64-0.13.0/lib/std/hash_map.zig:552:45: 0x10a000f in put (test)
            return self.unmanaged.putContext(self.allocator, key, value, self.ctx);
                                            ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/meter.zig:175:33: 0x109fc77 in registerInstrument (test)
        try self.instruments.put(id, instrument);
                                ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/meter.zig:120:36: 0x10a8363 in createCounter__anon_10931 (test)
        try self.registerInstrument(i);
                                   ^
/home/francesco/Projects/inge4pres/opentelemetry-zig/src/metrics/reader.zig:114:38: 0x10dccc5 in test.metric reader collects data from meter provider (test)
    var counter = try m.createCounter(u32, .{ .name = "my-counter" });
                                     ^
error: while executing test 'metrics.reader.test.metric reader collects data from meter provider', the following test command failed:
/home/francesco/Projects/inge4pres/opentelemetry-zig/.zig-cache/o/62efe2235f2265735cac6ce43158e291/test --listen=- 
Build Summary: 1/3 steps succeeded; 1 failed; 33/33 tests passed; 1 leaked (disable with --summary none)
test transitive failure
└─ run test 33/33 passed, 1 leaked
```